### PR TITLE
Feature/issue3057

### DIFF
--- a/grails-app/assets/javascripts/dataSets.js
+++ b/grails-app/assets/javascripts/dataSets.js
@@ -21,7 +21,11 @@ var DataSetsViewModel =function(dataSets, projectService, config) {
     self.newDataSet = function() {
         window.location.href = config.newDataSetUrl;
     };
-    
+
+    /** Only new data sets will have a created date, return true if any of the data sets have one */
+    self.supportsDateColumn = _.find(dataSets, function(dataSet) {
+        return dataSet.dateCreated;
+    })
     /** View model backing for a single row in the data set summary table */
     function DataSetSummary(dataSet) {
 

--- a/grails-app/assets/javascripts/dataSets.js
+++ b/grails-app/assets/javascripts/dataSets.js
@@ -25,7 +25,14 @@ var DataSetsViewModel =function(dataSets, projectService, config) {
     /** Only new data sets will have a created date, return true if any of the data sets have one */
     self.supportsDateColumn = _.find(dataSets, function(dataSet) {
         return dataSet.dateCreated;
-    })
+    });
+    function serviceName(serviceId) {
+        var service = _.find(config.services || [], function(service) {
+            return service.id == serviceId
+        });
+        return (service && service.name);
+    }
+
     /** View model backing for a single row in the data set summary table */
     function DataSetSummary(dataSet) {
 
@@ -36,6 +43,8 @@ var DataSetsViewModel =function(dataSets, projectService, config) {
         this.progress = dataSet.progress;
         this.dateCreated = ko.observable(dataSet.dateCreated).extend({simpleDate: false});
         this.lastUpdated = ko.observable(dataSet.lastUpdated).extend({simpleDate: false});
+        this.service = serviceName(dataSet.serviceId) || 'Unsupported service';
+
         this.deleteDataSet = function () {
             bootbox.confirm("Are you sure?", function (yes) {
                 if (yes) {

--- a/grails-app/assets/javascripts/dataSets.js
+++ b/grails-app/assets/javascripts/dataSets.js
@@ -21,19 +21,21 @@ var DataSetsViewModel =function(dataSets, projectService, config) {
     self.newDataSet = function() {
         window.location.href = config.newDataSetUrl;
     };
-
+    
     /** View model backing for a single row in the data set summary table */
     function DataSetSummary(dataSet) {
 
-        this.editUrl = config.editDataSetUrl + '?dataSetId='+dataSet.dataSetId;
-        this.viewUrl = config.viewDataSetUrl + '?dataSetId='+dataSet.dataSetId;
+        this.editUrl = config.editDataSetUrl + '?dataSetId=' + dataSet.dataSetId;
+        this.viewUrl = config.viewDataSetUrl + '?dataSetId=' + dataSet.dataSetId;
         this.name = dataSet.name;
         this.createdIn = dataSet.collectionApp === MONITOR_APP ? MONITOR_APP : 'MERIT';
         this.progress = dataSet.progress;
-        this.deleteDataSet = function() {
-            bootbox.confirm("Are you sure?", function(yes) {
+        this.dateCreated = ko.observable(dataSet.dateCreated).extend({simpleDate: false});
+        this.lastUpdated = ko.observable(dataSet.lastUpdated).extend({simpleDate: false});
+        this.deleteDataSet = function () {
+            bootbox.confirm("Are you sure?", function (yes) {
                 if (yes) {
-                    projectService.deleteDataSet(dataSet.dataSetId).done(function() {
+                    projectService.deleteDataSet(dataSet.dataSetId).done(function () {
                         blockUIWithMessage("Refreshing page...");
                         window.location.href = config.returnToUrl;
                     });

--- a/grails-app/assets/javascripts/dataSets.js
+++ b/grails-app/assets/javascripts/dataSets.js
@@ -43,7 +43,7 @@ var DataSetsViewModel =function(dataSets, projectService, config) {
         this.progress = dataSet.progress;
         this.dateCreated = ko.observable(dataSet.dateCreated).extend({simpleDate: false});
         this.lastUpdated = ko.observable(dataSet.lastUpdated).extend({simpleDate: false});
-        this.service = serviceName(dataSet.serviceId) || 'Unsupported service';
+        this.service = dataSet.serviceId ? (serviceName(dataSet.serviceId) || 'Unsupported service') : '';
 
         this.deleteDataSet = function () {
             bootbox.confirm("Are you sure?", function (yes) {

--- a/grails-app/assets/javascripts/enterActivityData.js
+++ b/grails-app/assets/javascripts/enterActivityData.js
@@ -208,10 +208,11 @@ var Master = function (activityId, config) {
             dirtyFlag: ko.simpleDirtyFlag,
             viewRootElementId: 'ko' + options.namespace
         };
-        context.lifecycleState = ko.observable('initialising');
+        // This was an observable but it's causing dirty checks to fail when the context changes state.
+        context.lifecycleState = {state:'initialising'};
         var config = _.defaults(options, defaults);
         var viewModel = new config.constructorFunction(output, config.model.dataModel, context, config);
-        context.lifecycleState('modelCreated');
+        context.lifecycleState.state = 'modelCreated';
         viewModel.initialise(output.data).done(function () {
 
             // Check for locally saved data for this output - this will happen in the event of a session timeout
@@ -234,7 +235,7 @@ var Master = function (activityId, config) {
             // register with the master controller so this model can participate in the save cycle
             self.register(viewModel, viewModel.modelForSaving, viewModel.dirtyFlag.isDirty, viewModel.dirtyFlag.reset);
 
-            context.lifecycleState('initialised');
+            context.lifecycleState.state = 'initialised';
 
         });
     }

--- a/grails-app/assets/javascripts/enterActivityData.js
+++ b/grails-app/assets/javascripts/enterActivityData.js
@@ -208,9 +208,10 @@ var Master = function (activityId, config) {
             dirtyFlag: ko.simpleDirtyFlag,
             viewRootElementId: 'ko' + options.namespace
         };
+        context.lifecycleState = ko.observable('initialising');
         var config = _.defaults(options, defaults);
         var viewModel = new config.constructorFunction(output, config.model.dataModel, context, config);
-
+        context.lifecycleState('modelCreated');
         viewModel.initialise(output.data).done(function () {
 
             // Check for locally saved data for this output - this will happen in the event of a session timeout
@@ -232,6 +233,8 @@ var Master = function (activityId, config) {
 
             // register with the master controller so this model can participate in the save cycle
             self.register(viewModel, viewModel.modelForSaving, viewModel.dirtyFlag.isDirty, viewModel.dirtyFlag.reset);
+
+            context.lifecycleState('initialised');
 
         });
     }

--- a/grails-app/assets/javascripts/projects.js
+++ b/grails-app/assets/javascripts/projects.js
@@ -1145,12 +1145,22 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
                 {
                     target: 2,
                     orderData: 3
+                },
+                {
+                    target: 5,
+                    visible: false,
+                    searchable: false
+                },
+                {
+                    target: 4,
+                    orderData: 5
                 }
             ],
             order: [3, 'desc']
         };
         if (!viewModel.supportsDateColumn) {
             dataTableConfig.columnDefs[2].visible = false;
+            dataTableConfig.columnDefs[4].visible = false;
             dataTableConfig.order = [1, 'asc'];
         }
 

--- a/grails-app/assets/javascripts/projects.js
+++ b/grails-app/assets/javascripts/projects.js
@@ -1119,6 +1119,7 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
 
     self.initialiseDataSets = function() {
         var dataSetsConfig = {
+            services: config.services,
             dataSetsSelector: config.dataSetsSelector || '#project-data-sets',
             newDataSetUrl:  config.newDataSetUrl,
             editDataSetUrl: config.editDataSetUrl,
@@ -1138,28 +1139,34 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
                     sortable: false
                 },
                 {
-                    target: 3,
-                    visible: false,
-                    searchable: false
-                },
-                {
                     target: 2,
-                    orderData: 3
+                    visible: true
                 },
                 {
-                    target: 5,
+                    target: 3,
+                    orderData: 4
+                },
+                {
+                    target: 4,
                     visible: false,
                     searchable: false
                 },
                 {
                     target: 4,
-                    orderData: 5
-                }
+                    orderData: 6
+                },
+                {
+                    target: 6,
+                    visible: false,
+                    searchable: false
+                },
+
             ],
             order: [3, 'desc']
         };
         if (!viewModel.supportsDateColumn) {
             dataTableConfig.columnDefs[2].visible = false;
+            dataTableConfig.columnDefs[3].visible = false;
             dataTableConfig.columnDefs[4].visible = false;
             dataTableConfig.order = [1, 'asc'];
         }

--- a/grails-app/assets/javascripts/projects.js
+++ b/grails-app/assets/javascripts/projects.js
@@ -1132,11 +1132,14 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
         ko.applyBindings(viewModel, $(dataSetsConfig.dataSetsSelector)[0]);
 
         var dataTableConfig = {
-            sortable:false,
             columnDefs: [
                 {
                     target: 0,
                     sortable: false
+                },
+                {
+                    target: 1,
+                    sortable: true
                 },
                 {
                     target: 2,
@@ -1144,6 +1147,7 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
                 },
                 {
                     target: 3,
+                    sortable: true,
                     orderData: 4
                 },
                 {
@@ -1152,7 +1156,8 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
                     searchable: false
                 },
                 {
-                    target: 4,
+                    target: 5,
+                    sortable:true,
                     orderData: 6
                 },
                 {
@@ -1167,7 +1172,7 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
         if (!viewModel.supportsDateColumn) {
             dataTableConfig.columnDefs[2].visible = false;
             dataTableConfig.columnDefs[3].visible = false;
-            dataTableConfig.columnDefs[4].visible = false;
+            dataTableConfig.columnDefs[5].visible = false;
             dataTableConfig.order = [1, 'asc'];
         }
 

--- a/grails-app/assets/javascripts/projects.js
+++ b/grails-app/assets/javascripts/projects.js
@@ -1129,6 +1129,28 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
         var projectService = new ProjectService({}, config);
         var viewModel = new DataSetsViewModel(project.custom && project.custom.dataSets, projectService, dataSetsConfig);
         ko.applyBindings(viewModel, $(dataSetsConfig.dataSetsSelector)[0]);
+        var dataTableConfig = {
+            sortable:false,
+            columnDefs: [
+                {
+                    target: 0,
+                    sortable: false
+                },
+                {
+                    target: 3,
+                    visible: false,
+                    searchable: false
+                },
+                {
+                    target: 2,
+                    orderData: 3
+                }
+            ],
+            order: [3, 'desc']
+        };
+
+        $(dataSetsConfig.dataSetsSelector).find('table').dataTable(dataTableConfig);
+
     };
 
     self.initialiseAdminTab = function() {

--- a/grails-app/assets/javascripts/projects.js
+++ b/grails-app/assets/javascripts/projects.js
@@ -1129,6 +1129,7 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
         var projectService = new ProjectService({}, config);
         var viewModel = new DataSetsViewModel(project.custom && project.custom.dataSets, projectService, dataSetsConfig);
         ko.applyBindings(viewModel, $(dataSetsConfig.dataSetsSelector)[0]);
+
         var dataTableConfig = {
             sortable:false,
             columnDefs: [
@@ -1148,6 +1149,10 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
             ],
             order: [3, 'desc']
         };
+        if (!viewModel.supportsDateColumn) {
+            dataTableConfig.columnDefs[2].visible = false;
+            dataTableConfig.order = [1, 'asc'];
+        }
 
         $(dataSetsConfig.dataSetsSelector).find('table').dataTable(dataTableConfig);
 

--- a/grails-app/assets/stylesheets/dataSets.css
+++ b/grails-app/assets/stylesheets/dataSets.css
@@ -6,21 +6,38 @@
 *= require_self
 */
 
-table td.actions, table th.actions {
-    width:10%;
+table.dataset-summary td.actions, table.dataset-summary th.actions {
+    width:3em;
 }
-table td.dataset-name, table th.dataset-name {
+table.dataset-summary td.dataset-name, table.dataset-summary th.dataset-name {
     width:65%;
 }
-table td.report-start, table th.report-start {
+table.dataset-summary td.report-start, table.dataset-summary th.report-start {
     width:15%;
 }
-div.otherPriority, div.other {
-    margin-top: 5px;
-}
-table td.dataset-progress, table th.dataset-progress {
+
+table.dataset-summary td.dataset-progress, table.dataset-summary th.dataset-progress {
     width:10em;
 }
+
+table.dataset-summary-with-dates td.actions, table.dataset-summary-with-dates th.actions {
+    width:3em;
+}
+table.dataset-summary-with-dates td.dataset-name, table.dataset-summary-with-dates th.dataset-name {
+    width:40%;
+}
+
+table.dataset-summary-with-dates td.service, table.dataset-summary-with-dates th.service {
+    width:25%;
+}
+table.dataset-summary td.dataset-progress, table.dataset-summary th.dataset-progress {
+    width:10em;
+}
+
 #dataCollectionOngoingDiv {
     margin-top: 10px;
+}
+
+div.otherPriority, div.other {
+    margin-top: 5px;
 }

--- a/grails-app/services/au/org/ala/merit/ProjectService.groovy
+++ b/grails-app/services/au/org/ala/merit/ProjectService.groovy
@@ -2103,9 +2103,11 @@ class ProjectService  {
         if(!dataSet.dataCollectionOngoing) {
             dataSet.dataCollectionOngoing = false
         }
+        dataSet.lastUpdated = DateUtils.formatAsISOStringNoMillis(new Date())
 
         if (!dataSet.dataSetId) {
             dataSet.dataSetId = UUID.randomUUID().toString()
+            dataSet.dateCreated = DateUtils.formatAsISOStringNoMillis(new Date())
             project.custom.dataSets << dataSet
         }
         else {

--- a/grails-app/views/project/dataset/_dataSets.gsp
+++ b/grails-app/views/project/dataset/_dataSets.gsp
@@ -9,7 +9,7 @@
             </div>
         </div>
     </div>
-    <table class="table table-striped w-100" data-bind="dataTable:dataTableConfig, css: { 'dataset-summary-with-dates':supportsDateColumn, 'data-dataset-summary':!supportsDateColumn }">
+    <table class="table table-striped w-100" data-bind="dataTable:dataTableConfig, css: { 'dataset-summary-with-dates':supportsDateColumn, 'dataset-summary':!supportsDateColumn }">
         <thead>
         <tr>
             <th class="actions">Actions</th>

--- a/grails-app/views/project/dataset/_dataSets.gsp
+++ b/grails-app/views/project/dataset/_dataSets.gsp
@@ -15,7 +15,9 @@
             <th class="actions">Actions</th>
             <th class="dataset-name">Title</th>
             <th class="date-created">Date Created</th>
-            <th class="date-created-hidden">Date Created (ISO format)</th>
+            <th class="date-created-hidden">Date created (ISO format)</th>
+            <th class="last-updated">Date last updated</th>
+            <th class="last-updated-hidden">Date last updated (ISO format)</th>
             <th class="created-in">Created in</th>
             <th class="dataset-progress">Status</th>
         </tr>
@@ -36,6 +38,8 @@
             <td class="dataset-name" data-bind="text:name"></td>
             <td class="date-created" data-bind="text:dateCreated.formattedDate"></td>
             <td class="date-created-hidden" data-bind="text:dateCreated"></td>
+            <td class="last-updated" data-bind="text:lastUpdated.formattedDate"></td>
+            <td class="last-updated-hidden" data-bind="text:lastUpdated"></td>
             <td class="created-in" data-bind="text:createdIn"></td>
             <td><button type="button" class="btn btn-sm" data-bind="activityProgress:progress">
                 <span data-bind="text: progress"></span>

--- a/grails-app/views/project/dataset/_dataSets.gsp
+++ b/grails-app/views/project/dataset/_dataSets.gsp
@@ -9,11 +9,13 @@
             </div>
         </div>
     </div>
-    <table class="table table-striped">
+    <table class="table table-striped w-100" data-bind="dataTable:dataTableConfig">
         <thead>
         <tr>
             <th class="actions">Actions</th>
             <th class="dataset-name">Title</th>
+            <th class="date-created">Date Created</th>
+            <th class="date-created-hidden">Date Created (ISO format)</th>
             <th class="created-in">Created in</th>
             <th class="dataset-progress">Status</th>
         </tr>
@@ -32,6 +34,8 @@
                 </a>
             </td>
             <td class="dataset-name" data-bind="text:name"></td>
+            <td class="date-created" data-bind="text:dateCreated.formattedDate"></td>
+            <td class="date-created-hidden" data-bind="text:dateCreated"></td>
             <td class="created-in" data-bind="text:createdIn"></td>
             <td><button type="button" class="btn btn-sm" data-bind="activityProgress:progress">
                 <span data-bind="text: progress"></span>

--- a/grails-app/views/project/dataset/_dataSets.gsp
+++ b/grails-app/views/project/dataset/_dataSets.gsp
@@ -9,12 +9,13 @@
             </div>
         </div>
     </div>
-    <table class="table table-striped w-100" data-bind="dataTable:dataTableConfig">
+    <table class="table table-striped w-100" data-bind="dataTable:dataTableConfig, css: { 'dataset-summary-with-dates':supportsDateColumn, 'data-dataset-summary':!supportsDateColumn }">
         <thead>
         <tr>
             <th class="actions">Actions</th>
             <th class="dataset-name">Title</th>
-            <th class="date-created">Date Created</th>
+            <th class="service">Service <fc:iconHelp>This data set can only be reported against the service specified</fc:iconHelp></th>
+            <th class="date-created">Date created</th>
             <th class="date-created-hidden">Date created (ISO format)</th>
             <th class="last-updated">Date last updated</th>
             <th class="last-updated-hidden">Date last updated (ISO format)</th>
@@ -36,6 +37,7 @@
                 </a>
             </td>
             <td class="dataset-name" data-bind="text:name"></td>
+            <td class="service" data-bind="text:service"></td>
             <td class="date-created" data-bind="text:dateCreated.formattedDate"></td>
             <td class="date-created-hidden" data-bind="text:dateCreated"></td>
             <td class="last-updated" data-bind="text:lastUpdated.formattedDate"></td>

--- a/src/integration-test/groovy/au/org/ala/fieldcapture/DatasetSpec.groovy
+++ b/src/integration-test/groovy/au/org/ala/fieldcapture/DatasetSpec.groovy
@@ -127,8 +127,12 @@ class DatasetSpec extends StubbedCasSpec{
         waitFor 10, {
             hasBeenReloaded()
         }
+        when:
+        def dataSetSummary = openDataSetSummaryTab()
+
+        then:
         waitFor 10, {
-           $('#project-data-sets tbody[data-bind*=dataSets] tr').size() == 0
+           dataSetSummary.dataSetSummaryCount() == 0
         }
 
     }

--- a/src/integration-test/groovy/pages/DataSetSummary.groovy
+++ b/src/integration-test/groovy/pages/DataSetSummary.groovy
@@ -13,6 +13,8 @@ class DataSetSummary extends Module {
         statusColumn(required: false) { $('#project-data-sets .dataset-progress') }
         status(required: false) {$('[data-bind*="text: progress"]')}
 
+        summaryTable(required: false) {$('#project-data-sets')}
+        tableEmptyMessage(required:false) {$('#project-data-sets td.dataTables_empty')}
     }
 
     void cancel() {
@@ -20,7 +22,7 @@ class DataSetSummary extends Module {
     }
 
     int dataSetSummaryCount() {
-        $('#project-data-sets tbody tr').size()
+        tableEmptyMessage.displayed ? 0 : summaryTable.find('tbody tr').size()
     }
 
 }


### PR DESCRIPTION
This is mostly changes for #3057 but there is also a change to the form initialisation to match the latest changes in the ecodata-client-plugin to support both improved change detection when constraints are initialised by ajax and allowing the new pre-pop behaviour to be configured to not run during initialisation - the purpose of which is to support fields that both get overwritten in response to changes to the data set dropdown, but also keep any customisations made after the data set is selected.