### PR TITLE
Only autosave MERI plan if in edit mode #1720

### DIFF
--- a/grails-app/assets/javascripts/meriplan.js
+++ b/grails-app/assets/javascripts/meriplan.js
@@ -82,6 +82,7 @@ function MERIPlan(project, projectService, config) {
             self.meriPlan().services.addServiceTarget(serviceTarget);
         });
         self.risks.load(meriPlan.risks);
+        self.applyAutoSave();
         self.attachFloatingSave();
 
     };
@@ -549,11 +550,7 @@ function MERIPlan(project, projectService, config) {
 
     };
 
-    if (!projectService.isProjectDetailsLocked()) {
-        // This was in DetailsViewModel to support the (never released) MERI plan load function.
-        // It's been moved back here as having in the DetailsViewModel was causing issues with the new MERI
-        // plan because orphaned services get detected as dirty and the user is prompted to save them, even when
-        // the page is in read only mode.
+    self.applyAutoSave = function() {
         autoSaveModel(
             self.meriPlan(),
             config.projectUpdateUrl,
@@ -570,6 +567,14 @@ function MERIPlan(project, projectService, config) {
                 dirtyFlagRateLimitMs: 500,
                 healthCheckUrl: config.healthCheckUrl
             });
+    }
+
+    if (!projectService.isProjectDetailsLocked()) {
+        // This was in DetailsViewModel to support the (never released) MERI plan load function.
+        // It's been moved back here as having in the DetailsViewModel was causing issues with the new MERI
+        // plan because orphaned services get detected as dirty and the user is prompted to save them, even when
+        // the page is in read only mode.
+        self.applyAutoSave();
     }
     var $floatingSave = $('#floating-save');
     var floatingSaveVisible = false;

--- a/grails-app/assets/javascripts/meriplan.js
+++ b/grails-app/assets/javascripts/meriplan.js
@@ -549,6 +549,28 @@ function MERIPlan(project, projectService, config) {
 
     };
 
+    if (!projectService.isProjectDetailsLocked()) {
+        // This was in DetailsViewModel to support the (never released) MERI plan load function.
+        // It's been moved back here as having in the DetailsViewModel was causing issues with the new MERI
+        // plan because orphaned services get detected as dirty and the user is prompted to save them, even when
+        // the page is in read only mode.
+        autoSaveModel(
+            self.meriPlan(),
+            config.projectUpdateUrl,
+            {
+                storageKey: config.meriStorageKey || 'meriPlan-' + project.projectId,
+                autoSaveIntervalInSeconds: config.autoSaveIntervalInSeconds || 60,
+                restoredDataWarningSelector: '#restoredData',
+                resultsMessageSelector: '.save-details-result-placeholder',
+                timeoutMessageSelector: '#timeoutMessage',
+                errorMessage: "Failed to save MERI Plan: ",
+                successMessage: 'MERI Plan saved',
+                preventNavigationIfDirty: true,
+                defaultDirtyFlag: ko.dirtyFlag,
+                dirtyFlagRateLimitMs: 500,
+                healthCheckUrl: config.healthCheckUrl
+            });
+    }
     var $floatingSave = $('#floating-save');
     var floatingSaveVisible = false;
     function checkSaveStatus(dirty) {
@@ -944,23 +966,6 @@ function DetailsViewModel(o, project, budgetHeaders, risks, allServices, selecte
     if (config.locked) {
         autoSaveConfig.lockedEntity = project.projectId;
     }
-
-    autoSaveModel(
-        self,
-        config.projectUpdateUrl,
-        {
-            storageKey:config.meriStorageKey || 'meriPlan-'+project.projectId,
-            autoSaveIntervalInSeconds:config.autoSaveIntervalInSeconds || 60,
-            restoredDataWarningSelector:'#restoredData',
-            resultsMessageSelector:'.save-details-result-placeholder',
-            timeoutMessageSelector:'#timeoutMessage',
-            errorMessage:"Failed to save MERI Plan: ",
-            successMessage: 'MERI Plan saved',
-            preventNavigationIfDirty:true,
-            defaultDirtyFlag:ko.dirtyFlag,
-            dirtyFlagRateLimitMs: 500,
-            healthCheckUrl:config.healthCheckUrl
-        });
 };
 
 /** Removes nulls from arrays after toJSON is called */

--- a/grails-app/assets/javascripts/projects.js
+++ b/grails-app/assets/javascripts/projects.js
@@ -1185,8 +1185,12 @@ function ProjectPageViewModel(project, sites, activities, organisations, userRol
         var meriPlanSection = document.getElementById("edit-meri-plan");
         if (meriPlanSection) {
             ko.applyBindings(self.meriPlan, meriPlanSection);
-            self.meriPlan.meriPlan().dirtyFlag.reset();
-            self.meriPlan.attachFloatingSave();
+            // The dirty flag is only attached if the MERI plan is in edit mode.
+            if (self.meriPlan.meriPlan().dirtyFlag) {
+                self.meriPlan.meriPlan().dirtyFlag.reset();
+                self.meriPlan.attachFloatingSave();
+            }
+
         }
 
         // When the MERI plan is approved, the announcements move to their own section, otherwise they

--- a/src/test/js/spec/MeriPlanSpec.js
+++ b/src/test/js/spec/MeriPlanSpec.js
@@ -195,7 +195,8 @@ describe("Loading the MERI plan is handled correctly", function () {
             plannedStartDate:'2018-07-01T00:00:00Z',
             plannedEndDate:'2021-06-30T00:00:00Z'
         };
-        var projectService = new ProjectService(project, {});
+
+        var projectService = new ProjectService(project, {userHoldsMeriPlanLock:true});
 
         var viewModel = new MERIPlan(project, projectService, config);
 


### PR DESCRIPTION
I noticed this was causing issues - even when the MERI plan wasn't locked for editing if there were orphaned services the plan was being marked as edited until the MERI plan tab was opened and the binding resets the dirty flag.
We should only be applying the autosave if the MERI plan is editable.