### PR TITLE
AtlasOfLivingAustralia/ecodata#1049

### DIFF
--- a/forms/mongo/insertParatooProtocolConfig.js
+++ b/forms/mongo/insertParatooProtocolConfig.js
@@ -346,12 +346,7 @@ var protocols = {
                     "dataType": "species"
                 },
                 "recruitment-sapling-and-seedling-count.juvenile_count": {
-                    "dwcAttribute": "individualCount"
-                },
-                "recruitment-sapling-and-seedling-count.seedling_count": {
-                    "dwcAttribute": "individualCount"
-                },
-                "recruitment-sapling-and-seedling-count.sapling_count": {
+                    "dwcExpression": "(juvenile_count ?:0) + (seedling_count ?:0) + (sapling_count ?:0)",
                     "dwcAttribute": "individualCount"
                 },
                 "recruitment-sapling-and-seedling-count.voucher_full.host_species": {

--- a/forms/mongo/insertParatooProtocolConfig.js
+++ b/forms/mongo/insertParatooProtocolConfig.js
@@ -346,7 +346,7 @@ var protocols = {
                     "dataType": "species"
                 },
                 "recruitment-sapling-and-seedling-count.juvenile_count": {
-                    "dwcExpression": "(juvenile_count ?:0) + (seedling_count ?:0) + (sapling_count ?:0)",
+                    "dwcExpression": "(['juvenile_count'] == null ? 0 : ['juvenile_count']) + (['seedling_count'] == null ? 0 : ['seedling_count']) + (['sapling_count'] == null ? 0 :['sapling_count'])",
                     "dwcAttribute": "individualCount"
                 },
                 "recruitment-sapling-and-seedling-count.voucher_full.host_species": {


### PR DESCRIPTION
- supports individual count in recruitment protocol to be a sum of juvenile_count, seedling_count and sapling_count