### PR TITLE
Only allow alphanumerics and _ in BDR filenames as ArcGIS can be fuss…

### DIFF
--- a/grails-app/services/au/org/ala/merit/BdrService.groovy
+++ b/grails-app/services/au/org/ala/merit/BdrService.groovy
@@ -29,6 +29,8 @@ class BdrService {
     ]
 
     static private String buildFileName(String fileName, String format) {
+        // Remove any non-alphanumeric characters from the file name and replace spaces with underscores
+        fileName = fileName.replaceAll(' ', '_').replaceAll(/[^a-zA-Z0-9_]/, '')
         fileName+'.'+FILE_EXTENSION_MAP[format]
     }
 

--- a/src/test/groovy/au/org/ala/merit/BdrServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/merit/BdrServiceSpec.groovy
@@ -76,4 +76,20 @@ class BdrServiceSpec extends Specification implements ServiceUnitTest<BdrService
         1 * bdrTokenService.getBDRAccessToken() >> azureToken
         1 * webService.proxyGetRequest(response, expectedBdrApiUrl, expectedParams, WebService.AUTHORIZATION_HEADER_TYPE_EXTERNAL_TOKEN, readTimeout, azureToken, headers)
     }
+
+    def "When datasets are downloaded from the BDR, the content disposition filename should only include alphanumerics and underscores"(String fileName, String format, String expectedFileName) {
+        when:
+        String result = service.buildFileName(fileName, format)
+
+        then:
+        result == expectedFileName
+
+        where:
+        fileName | format | expectedFileName
+        "test file name" | "application/json" | "test_file_name.json"
+        "test file name" | "application/geo+json" | "test_file_name.geojson"
+        "data_set_summary" | "application/json" | "data_set_summary.json"
+        "This is a project with special @ characters'" | "application/json" | "This_is_a_project_with_special__characters.json"
+
+    }
 }


### PR DESCRIPTION
When testing, the team had issues importing data into ArcGIS but QGIS was OK.  Some googling indicated ArcGIS might be old school with filename requirements so I've changed MERIT to create modified names with only alpha numerics and underscores in case that helps.