### PR TITLE
Allow support officers to withdraw org and MU reports #3770

### DIFF
--- a/grails-app/controllers/au/org/ala/merit/ManagementUnitController.groovy
+++ b/grails-app/controllers/au/org/ala/merit/ManagementUnitController.groovy
@@ -283,7 +283,9 @@ class ManagementUnitController {
         render result as JSON
     }
 
-    @PreAuthorise(accessLevel = 'caseManager')
+    // we are using accessLevel=officer here rather than accessLevel=caseManager to allow "Support Officers" to be able to
+    // return reports without adding themselves to the project as a grant manager.
+    @PreAuthorise(accessLevel = 'officer')
     def ajaxRejectReport(String id) {
 
         def reportDetails = request.JSON

--- a/grails-app/controllers/au/org/ala/merit/OrganisationController.groovy
+++ b/grails-app/controllers/au/org/ala/merit/OrganisationController.groovy
@@ -665,7 +665,9 @@ class OrganisationController {
         render result as JSON
     }
 
-    @PreAuthorise(accessLevel = 'caseManager')
+    // we are using accessLevel=officer here rather than accessLevel=caseManager to allow "Support Officers" to be able to\
+    // return reports without adding themselves to the project as a grant manager.
+    @PreAuthorise(accessLevel = 'officer')
     def ajaxRejectReport(String id) {
 
         if (!organisationService.isUserGrantManagerForOrganisation(id)) {


### PR DESCRIPTION
Dave found while testing that we never implemented the ability for support officers to withdraw org reports